### PR TITLE
[11.x] Define lrem method in PhpRedisConnection

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -162,6 +162,21 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     }
 
     /**
+     * Returns the specified elements of the list stored at key.
+     *
+     * @param string $key
+     * @param int|string $start
+     * @param int|string $stop
+     * @return array|null
+     */
+    public function lrange($key, $start, $stop)
+    {
+        $result = $this->command('lrange', [$key, $start, $stop]);
+
+        return empty($result) ? null : $result;
+    }
+
+    /**
      * Removes and returns the first element of the list stored at key.
      *
      * @param  mixed  ...$arguments

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -162,21 +162,6 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     }
 
     /**
-     * Returns the specified elements of the list stored at key.
-     *
-     * @param string $key
-     * @param int|string $start
-     * @param int|string $stop
-     * @return array|null
-     */
-    public function lrange($key, $start, $stop)
-    {
-        $result = $this->command('lrange', [$key, $start, $stop]);
-
-        return empty($result) ? null : $result;
-    }
-
-    /**
      * Removes and returns the first element of the list stored at key.
      *
      * @param  mixed  ...$arguments
@@ -326,8 +311,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function scan($cursor, $options = [])
     {
-        $result = $this->client->scan(
-            $cursor,
+        $result = $this->client->scan($cursor,
             $options['match'] ?? '*',
             $options['count'] ?? 10
         );
@@ -349,9 +333,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function zscan($key, $cursor, $options = [])
     {
-        $result = $this->client->zscan(
-            $key,
-            $cursor,
+        $result = $this->client->zscan($key, $cursor,
             $options['match'] ?? '*',
             $options['count'] ?? 10
         );
@@ -373,9 +355,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function hscan($key, $cursor, $options = [])
     {
-        $result = $this->client->hscan(
-            $key,
-            $cursor,
+        $result = $this->client->hscan($key, $cursor,
             $options['match'] ?? '*',
             $options['count'] ?? 10
         );
@@ -397,9 +377,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function sscan($key, $cursor, $options = [])
     {
-        $result = $this->client->sscan(
-            $key,
-            $cursor,
+        $result = $this->client->sscan($key, $cursor,
             $options['match'] ?? '*',
             $options['count'] ?? 10
         );

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -162,6 +162,21 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     }
 
     /**
+     * Returns the specified elements of the list stored at key.
+     *
+     * @param string $key
+     * @param int|string $start
+     * @param int|string $stop
+     * @return array|null
+     */
+    public function lrange($key, $start, $stop)
+    {
+        $result = $this->command('lrange', [$key, $start, $stop]);
+
+        return empty($result) ? null : $result;
+    }
+
+    /**
      * Removes and returns the first element of the list stored at key.
      *
      * @param  mixed  ...$arguments
@@ -311,7 +326,8 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function scan($cursor, $options = [])
     {
-        $result = $this->client->scan($cursor,
+        $result = $this->client->scan(
+            $cursor,
             $options['match'] ?? '*',
             $options['count'] ?? 10
         );
@@ -333,7 +349,9 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function zscan($key, $cursor, $options = [])
     {
-        $result = $this->client->zscan($key, $cursor,
+        $result = $this->client->zscan(
+            $key,
+            $cursor,
             $options['match'] ?? '*',
             $options['count'] ?? 10
         );
@@ -355,7 +373,9 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function hscan($key, $cursor, $options = [])
     {
-        $result = $this->client->hscan($key, $cursor,
+        $result = $this->client->hscan(
+            $key,
+            $cursor,
             $options['match'] ?? '*',
             $options['count'] ?? 10
         );
@@ -377,7 +397,9 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function sscan($key, $cursor, $options = [])
     {
-        $result = $this->client->sscan($key, $cursor,
+        $result = $this->client->sscan(
+            $key,
+            $cursor,
             $options['match'] ?? '*',
             $options['count'] ?? 10
         );


### PR DESCRIPTION
This PR defines the `lrange`method in the Illuminate/Redis/Connections/PhpRedisConnection.php class, instead of using the magic  `__call()` method to pass the command down to the underlying client.

This will help IDEs to recognize the command, and enables type hinting in the future.